### PR TITLE
fix: data labels v2

### DIFF
--- a/src/charts/common/bar/DataLabels.js
+++ b/src/charts/common/bar/DataLabels.js
@@ -558,7 +558,7 @@ export default class BarDataLabels {
         parent: elDataLabelsWrap,
         dataLabelsConfig: modifiedDataLabelsConfig,
         alwaysDrawDataLabel: true,
-        offsetCorrection: true
+        offsetCorrection: false
       })
     }
 


### PR DESCRIPTION
This PR fixes the bug in apex charts that hides the labels when bars are close to beginning or end

[Fabriq Ticket](https://la.fabriq.tech/?ticket=433891)
[Apex chart "fix"](https://github.com/apexcharts/apexcharts.js/issues/2264)